### PR TITLE
Client cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+build.rc

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -25,17 +25,15 @@ import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
 import org.sonatype.ossindex.service.client.OssindexClient;
-import org.sonatype.ossindex.service.client.cache.ComponentReportCache;
-import org.sonatype.ossindex.service.client.cache.MemoryCache;
-import org.sonatype.ossindex.service.client.marshal.GsonMarshaller;
 import org.sonatype.ossindex.service.client.internal.OssindexClientImpl;
 import org.sonatype.ossindex.service.client.internal.VersionSupplier;
-import org.sonatype.ossindex.service.client.transport.UserAgentSupplier;
-import org.sonatype.ossindex.service.client.transport.HttpClientTransport;
+import org.sonatype.ossindex.service.client.marshal.GsonMarshaller;
 import org.sonatype.ossindex.service.client.marshal.Marshaller;
+import org.sonatype.ossindex.service.client.transport.HttpClientTransport;
 import org.sonatype.ossindex.service.client.transport.Transport;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder.Product;
+import org.sonatype.ossindex.service.client.transport.UserAgentSupplier;
 
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.maven.artifact.Artifact;
@@ -147,10 +145,7 @@ public class ComponentReportAssistant
     Transport transport = new HttpClientTransport(userAgent);
     Marshaller marshaller = new GsonMarshaller();
 
-    // TODO: expose cache for configuration
-    ComponentReportCache reportCache = new MemoryCache();
-
-    return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller, reportCache);
+    return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller);
   }
 
   /**

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -25,6 +25,8 @@ import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
 import org.sonatype.ossindex.service.client.OssindexClient;
+import org.sonatype.ossindex.service.client.cache.ComponentReportCache;
+import org.sonatype.ossindex.service.client.cache.MemoryComponentReportCache;
 import org.sonatype.ossindex.service.client.internal.GsonMarshaller;
 import org.sonatype.ossindex.service.client.internal.OssindexClientImpl;
 import org.sonatype.ossindex.service.client.internal.VersionSupplier;
@@ -136,7 +138,8 @@ public class ComponentReportAssistant
     };
     Transport transport = new HttpClientTransport(userAgent);
     Marshaller marshaller = new GsonMarshaller();
-    return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller);
+    ComponentReportCache reportCache = new MemoryComponentReportCache();
+    return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller, reportCache);
   }
 
   /**

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -27,12 +27,12 @@ import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerab
 import org.sonatype.ossindex.service.client.OssindexClient;
 import org.sonatype.ossindex.service.client.cache.ComponentReportCache;
 import org.sonatype.ossindex.service.client.cache.MemoryCache;
-import org.sonatype.ossindex.service.client.internal.GsonMarshaller;
+import org.sonatype.ossindex.service.client.marshal.GsonMarshaller;
 import org.sonatype.ossindex.service.client.internal.OssindexClientImpl;
 import org.sonatype.ossindex.service.client.internal.VersionSupplier;
 import org.sonatype.ossindex.service.client.transport.UserAgentSupplier;
 import org.sonatype.ossindex.service.client.transport.HttpClientTransport;
-import org.sonatype.ossindex.service.client.transport.Marshaller;
+import org.sonatype.ossindex.service.client.marshal.Marshaller;
 import org.sonatype.ossindex.service.client.transport.Transport;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder.Product;

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -146,7 +146,10 @@ public class ComponentReportAssistant
     };
     Transport transport = new HttpClientTransport(userAgent);
     Marshaller marshaller = new GsonMarshaller();
+
+    // TODO: expose cache for configuration
     ComponentReportCache reportCache = new MemoryComponentReportCache();
+
     return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller, reportCache);
   }
 

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -26,7 +26,7 @@ import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
 import org.sonatype.ossindex.service.client.OssindexClient;
 import org.sonatype.ossindex.service.client.cache.ComponentReportCache;
-import org.sonatype.ossindex.service.client.cache.MemoryComponentReportCache;
+import org.sonatype.ossindex.service.client.cache.MemoryCache;
 import org.sonatype.ossindex.service.client.internal.GsonMarshaller;
 import org.sonatype.ossindex.service.client.internal.OssindexClientImpl;
 import org.sonatype.ossindex.service.client.internal.VersionSupplier;
@@ -148,7 +148,7 @@ public class ComponentReportAssistant
     Marshaller marshaller = new GsonMarshaller();
 
     // TODO: expose cache for configuration
-    ComponentReportCache reportCache = new MemoryComponentReportCache();
+    ComponentReportCache reportCache = new MemoryCache();
 
     return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller, reportCache);
   }

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -78,8 +78,8 @@ public class ComponentReportAssistant
     log.info("Exclude vulnerability identifiers: {}", request.getExcludeVulnerabilityIds());
     log.info("CVSS-score threshold: {}", request.getCvssScoreThreshold());
 
-    OssindexClient client = createClient(request);
     ComponentReportResult result = new ComponentReportResult();
+    OssindexClient client = createClient(request);
     try {
       Map<PackageUrl, ComponentReport> reports = client.requestComponentReports(new ArrayList<>(purlArtifacts.keySet()));
       log.trace("Fetched {} component-reports", reports.size());
@@ -98,6 +98,14 @@ public class ComponentReportAssistant
     }
     catch (Exception e) {
       log.warn("Failed to fetch component-reports", e);
+    }
+    finally {
+      try {
+        client.close();
+      }
+      catch (Exception e) {
+        log.warn("Failed to close client", e);
+      }
     }
 
     return result;

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -149,6 +149,8 @@ public class ComponentReportAssistant
 
     OssindexClientConfiguration config = request.getClientConfiguration();
 
+    // TODO: allow cache to be disabled?  or select type from property?
+
     // maybe adapt cache
     if (config.getCacheConfiguration() == null) {
       config.setCacheConfiguration(new DirectoryCache.Configuration());

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -25,6 +25,8 @@ import org.sonatype.goodies.packageurl.PackageUrl;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReport;
 import org.sonatype.ossindex.service.api.componentreport.ComponentReportVulnerability;
 import org.sonatype.ossindex.service.client.OssindexClient;
+import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
+import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.internal.OssindexClientImpl;
 import org.sonatype.ossindex.service.client.internal.VersionSupplier;
 import org.sonatype.ossindex.service.client.marshal.GsonMarshaller;
@@ -145,7 +147,14 @@ public class ComponentReportAssistant
     Transport transport = new HttpClientTransport(userAgent);
     Marshaller marshaller = new GsonMarshaller();
 
-    return new OssindexClientImpl(request.getClientConfiguration(), transport, marshaller);
+    OssindexClientConfiguration config = request.getClientConfiguration();
+
+    // maybe adapt cache
+    if (config.getCacheConfiguration() == null) {
+      config.setCacheConfiguration(new DirectoryCache.Configuration());
+    }
+
+    return new OssindexClientImpl(config, transport, marshaller);
   }
 
   /**

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportRequest.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportRequest.java
@@ -15,6 +15,7 @@ package org.sonatype.ossindex.maven.common;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Properties;
 import java.util.Set;
 
 import javax.annotation.Nullable;
@@ -32,6 +33,9 @@ import org.apache.maven.artifact.Artifact;
 public class ComponentReportRequest
 {
   private OssindexClientConfiguration clientConfiguration;
+
+  @Nullable
+  private Properties properties;
 
   /**
    * Artifact (components) to analyze.
@@ -65,6 +69,21 @@ public class ComponentReportRequest
 
   public void setClientConfiguration(final OssindexClientConfiguration clientConfiguration) {
     this.clientConfiguration = clientConfiguration;
+  }
+
+  /**
+   * @since ???
+   */
+  @Nullable
+  public Properties getProperties() {
+    return properties;
+  }
+
+  /**
+   * @since ???
+   */
+  public void setProperties(@Nullable final Properties properties) {
+    this.properties = properties;
   }
 
   public Collection<Artifact> getComponents() {

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/PropertyHelper.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/PropertyHelper.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (c) 2018-present Sonatype, Inc. All rights reserved.
+ *
+ * This program is licensed to you under the Apache License Version 2.0,
+ * and you may not use this file except in compliance with the Apache License Version 2.0.
+ * You may obtain a copy of the Apache License Version 2.0 at http://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the Apache License Version 2.0 is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Apache License Version 2.0 for the specific language governing permissions and limitations there under.
+ */
+package org.sonatype.ossindex.maven.common;
+
+import java.io.File;
+import java.util.Properties;
+
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+/**
+ * Property helper.
+ *
+ * @since ???
+ */
+public class PropertyHelper
+{
+  private static final Logger log = LoggerFactory.getLogger(PropertyHelper.class);
+
+  /**
+   * Merge properties.
+   */
+  public static Properties merge(final Properties first, final Properties second) {
+    checkNotNull(first);
+    checkNotNull(second);
+
+    Properties merged = new Properties();
+    merged.putAll(first);
+    merged.putAll(second);
+
+    return merged;
+  }
+
+  /**
+   * Get string property.
+   */
+  @Nullable
+  public static String getString(final Properties properties, final String name) {
+    checkNotNull(properties);
+    checkNotNull(name);
+
+    String value = properties.getProperty(name);
+    log.trace("Property: {}={}", name, value);
+    return value;
+  }
+
+  /**
+   * Get boolean property.
+   */
+  public static boolean getBoolean(final Properties properties, final String name, final boolean defaultValue) {
+    String value = getString(properties, name);
+    if (value != null) {
+      return Boolean.parseBoolean(value);
+    }
+    return defaultValue;
+  }
+
+  /**
+   * Get file property.
+   */
+  @Nullable
+  public static File getFile(final Properties properties, final String name) {
+    String value = getString(properties, name);
+    if (value != null) {
+      return new File(value);
+    }
+    return null;
+  }
+}

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -25,6 +25,7 @@ import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
+import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
@@ -203,6 +204,11 @@ public class BanVulnerableDependencies
 
       // adapt maven http-proxy settings to client configuration
       maybeApplyProxy(clientConfiguration);
+
+      // adapt cache directory
+      if (clientConfiguration.getCacheConfiguration() == null) {
+        clientConfiguration.setCacheConfiguration(new DirectoryCache.Configuration());
+      }
 
       ComponentReportRequest reportRequest = new ComponentReportRequest();
       reportRequest.setProducts(ImmutableList.of(

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -25,7 +25,6 @@ import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
-import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
@@ -204,11 +203,6 @@ public class BanVulnerableDependencies
 
       // adapt maven http-proxy settings to client configuration
       maybeApplyProxy(clientConfiguration);
-
-      // adapt cache directory
-      if (clientConfiguration.getCacheConfiguration() == null) {
-        clientConfiguration.setCacheConfiguration(new DirectoryCache.Configuration());
-      }
 
       ComponentReportRequest reportRequest = new ComponentReportRequest();
       reportRequest.setProducts(ImmutableList.of(

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -24,6 +24,7 @@ import org.sonatype.ossindex.maven.common.ComponentReportAssistant;
 import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
+import org.sonatype.ossindex.maven.common.PropertyHelper;
 import org.sonatype.ossindex.maven.common.Version;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
@@ -205,6 +206,7 @@ public class BanVulnerableDependencies
       maybeApplyProxy(clientConfiguration);
 
       ComponentReportRequest reportRequest = new ComponentReportRequest();
+      reportRequest.setProperties(PropertyHelper.merge(project.getProperties(), session.getUserProperties()));
       reportRequest.setProducts(ImmutableList.of(
           new Product("Maven", mavenVersion),
           new Product("Enforcer-Rule", Version.get().getVersion())

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -25,8 +25,6 @@ import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
-import org.sonatype.ossindex.service.client.cache.CacheConfiguration;
-import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
@@ -138,15 +136,6 @@ public class BanVulnerableDependencies
     this.excludeVulnerabilityIds = excludeVulnerabilityIds;
   }
 
-  /**
-   * Report cache directory.
-   *
-   * @since ???
-   */
-  public void setReportCacheDir(@Nullable final File reportCacheDir) {
-    this.reportCacheDir = reportCacheDir;
-  }
-
   @Override
   public void execute(@Nonnull final EnforcerRuleHelper helper) throws EnforcerRuleException {
     new Task(helper).run();
@@ -214,12 +203,6 @@ public class BanVulnerableDependencies
 
       // adapt maven http-proxy settings to client configuration
       maybeApplyProxy(clientConfiguration);
-
-      // adapt cache directory
-      if (reportCacheDir != null) {
-        CacheConfiguration cacheConfiguration = new DirectoryCache.Configuration(reportCacheDir.toPath(), null);
-        clientConfiguration.setCacheConfiguration(cacheConfiguration);
-      }
 
       ComponentReportRequest reportRequest = new ComponentReportRequest();
       reportRequest.setProducts(ImmutableList.of(

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -139,6 +139,8 @@ public class BanVulnerableDependencies
   }
 
   /**
+   * Report cache directory.
+   *
    * @since ???
    */
   public void setReportCacheDir(@Nullable final File reportCacheDir) {

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -24,9 +24,9 @@ import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
-import org.sonatype.ossindex.service.client.AuthConfiguration;
+import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
-import org.sonatype.ossindex.service.client.ProxyConfiguration;
+import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder.Product;
 
 import com.google.common.base.Splitter;

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -12,6 +12,7 @@
  */
 package org.sonatype.ossindex.maven.enforcer;
 
+import java.io.File;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -24,6 +25,8 @@ import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
+import org.sonatype.ossindex.service.client.cache.CacheConfiguration;
+import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
@@ -68,6 +71,14 @@ public class BanVulnerableDependencies
   private float cvssScoreThreshold = 0;
 
   private Set<String> excludeVulnerabilityIds = new HashSet<>();
+
+  /**
+   * Report cache directory.
+   *
+   * @since ???
+   */
+  @Nullable
+  private File reportCacheDir;
 
   /**
    * <a href="https://ossindex.sonatype.org/">Sonatype OSS Index</a> client configuration.
@@ -125,6 +136,13 @@ public class BanVulnerableDependencies
   @SuppressWarnings("unused")
   public void setExcludeVulnerabilityIds(final Set<String> excludeVulnerabilityIds) {
     this.excludeVulnerabilityIds = excludeVulnerabilityIds;
+  }
+
+  /**
+   * @since ???
+   */
+  public void setReportCacheDir(@Nullable final File reportCacheDir) {
+    this.reportCacheDir = reportCacheDir;
   }
 
   @Override
@@ -194,6 +212,12 @@ public class BanVulnerableDependencies
 
       // adapt maven http-proxy settings to client configuration
       maybeApplyProxy(clientConfiguration);
+
+      // adapt cache directory
+      if (reportCacheDir != null) {
+        CacheConfiguration cacheConfiguration = new DirectoryCache.Configuration(reportCacheDir.toPath(), null);
+        clientConfiguration.setCacheConfiguration(cacheConfiguration);
+      }
 
       ComponentReportRequest reportRequest = new ComponentReportRequest();
       reportRequest.setProducts(ImmutableList.of(

--- a/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
@@ -25,6 +25,7 @@ import org.sonatype.ossindex.maven.common.ComponentReportAssistant;
 import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
+import org.sonatype.ossindex.maven.common.PropertyHelper;
 import org.sonatype.ossindex.maven.common.Version;
 import org.sonatype.ossindex.maven.plugin.export.Exporter;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
@@ -230,6 +231,8 @@ public class AuditMojo
     maybeApplyProxy(clientConfiguration);
 
     ComponentReportRequest reportRequest = new ComponentReportRequest();
+    reportRequest.setProperties(PropertyHelper.merge(project.getProperties(), session.getUserProperties()));
+
     reportRequest.setProducts(ImmutableList.of(
         new Product("Maven", mavenVersion),
         new Product("Maven-Plugin", Version.get().getVersion())

--- a/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
@@ -28,7 +28,6 @@ import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
 import org.sonatype.ossindex.maven.plugin.export.Exporter;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
-import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder.Product;
@@ -229,11 +228,6 @@ public class AuditMojo
 
     // adapt maven http-proxy settings to client configuration
     maybeApplyProxy(clientConfiguration);
-
-    // adapt cache directory
-    if (clientConfiguration.getCacheConfiguration() == null) {
-      clientConfiguration.setCacheConfiguration(new DirectoryCache.Configuration());
-    }
 
     ComponentReportRequest reportRequest = new ComponentReportRequest();
     reportRequest.setProducts(ImmutableList.of(

--- a/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
@@ -27,9 +27,9 @@ import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
 import org.sonatype.ossindex.maven.plugin.export.Exporter;
-import org.sonatype.ossindex.service.client.AuthConfiguration;
+import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
-import org.sonatype.ossindex.service.client.ProxyConfiguration;
+import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder.Product;
 
 import com.google.common.base.Splitter;

--- a/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
@@ -28,7 +28,6 @@ import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
 import org.sonatype.ossindex.maven.plugin.export.Exporter;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
-import org.sonatype.ossindex.service.client.cache.CacheConfiguration;
 import org.sonatype.ossindex.service.client.cache.DirectoryCache;
 import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
@@ -181,15 +180,6 @@ public class AuditMojo
   @Parameter(property = "ossindex.reportFile")
   private File reportFile;
 
-  /**
-   * Report cache directory.
-   *
-   * @since ???
-   */
-  @Nullable
-  @Parameter(property = "ossindex.reportCacheDirectory")
-  private File reportCacheDir;
-
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
@@ -241,9 +231,8 @@ public class AuditMojo
     maybeApplyProxy(clientConfiguration);
 
     // adapt cache directory
-    if (reportCacheDir != null) {
-      CacheConfiguration cacheConfiguration = new DirectoryCache.Configuration(reportCacheDir.toPath(), null);
-      clientConfiguration.setCacheConfiguration(cacheConfiguration);
+    if (clientConfiguration.getCacheConfiguration() == null) {
+      clientConfiguration.setCacheConfiguration(new DirectoryCache.Configuration());
     }
 
     ComponentReportRequest reportRequest = new ComponentReportRequest();

--- a/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
+++ b/maven-plugin/src/main/java/org/sonatype/ossindex/maven/plugin/AuditMojo.java
@@ -27,8 +27,10 @@ import org.sonatype.ossindex.maven.common.ComponentReportResult;
 import org.sonatype.ossindex.maven.common.MavenCoordinates;
 import org.sonatype.ossindex.maven.common.Version;
 import org.sonatype.ossindex.maven.plugin.export.Exporter;
-import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.OssindexClientConfiguration;
+import org.sonatype.ossindex.service.client.cache.CacheConfiguration;
+import org.sonatype.ossindex.service.client.cache.DirectoryCache;
+import org.sonatype.ossindex.service.client.transport.AuthConfiguration;
 import org.sonatype.ossindex.service.client.transport.ProxyConfiguration;
 import org.sonatype.ossindex.service.client.transport.UserAgentBuilder.Product;
 
@@ -179,6 +181,15 @@ public class AuditMojo
   @Parameter(property = "ossindex.reportFile")
   private File reportFile;
 
+  /**
+   * Report cache directory.
+   *
+   * @since ???
+   */
+  @Nullable
+  @Parameter(property = "ossindex.reportCacheDirectory")
+  private File reportCacheDir;
+
   @Override
   public void execute() throws MojoExecutionException, MojoFailureException {
     if (skip) {
@@ -228,6 +239,12 @@ public class AuditMojo
 
     // adapt maven http-proxy settings to client configuration
     maybeApplyProxy(clientConfiguration);
+
+    // adapt cache directory
+    if (reportCacheDir != null) {
+      CacheConfiguration cacheConfiguration = new DirectoryCache.Configuration(reportCacheDir.toPath(), null);
+      clientConfiguration.setCacheConfiguration(cacheConfiguration);
+    }
 
     ComponentReportRequest reportRequest = new ComponentReportRequest();
     reportRequest.setProducts(ImmutableList.of(

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
       <dependency>
         <groupId>org.sonatype.ossindex</groupId>
         <artifactId>ossindex-service-client</artifactId>
-        <version>1.0.3</version>
+        <version>1-SNAPSHOT</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Hook up simple directory-based persistent cache to maven goal and enforcer rule; adapt to related api changes.
 
Related:
* https://github.com/sonatype/ossindex-service/pull/103