### PR TITLE
Upgrade to maven-enforcer-api 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ For information on how to use the integrations see the project documentation:
 ### Requirements
 
 * [Apache Maven](https://maven.apache.org/) 3.3+ (prefer to use included `mvnw`)
-* JDK 7+ (10 is **NOT** supported)
+* JDK 8+ (10 is **NOT** supported)
 
 ### Build
 

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -46,7 +46,6 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>3.0</version>
     </dependency>
 
     <dependency>

--- a/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
+++ b/common/src/main/java/org/sonatype/ossindex/maven/common/ComponentReportAssistant.java
@@ -124,7 +124,7 @@ public class ComponentReportAssistant
    */
   @VisibleForTesting
   static PackageUrl packageUrl(final Artifact artifact) {
-    return new PackageUrl.Builder()
+    return PackageUrl.builder()
         .type("maven")
         .namespace(artifact.getGroupId())
         .name(artifact.getArtifactId())

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>org.apache.maven.enforcer</groupId>
       <artifactId>enforcer-api</artifactId>
-      <version>3.0.0-M1</version>
+      <version>3.0.0</version>
     </dependency>
 
     <dependency>
@@ -64,11 +64,9 @@
       <artifactId>maven-artifact</artifactId>
     </dependency>
 
-    <!-- maven-enforcer-plugin uses older maven-dependency-tree 2.x API and is not compatible with latest 3.x -->
     <dependency>
       <groupId>org.apache.maven.shared</groupId>
       <artifactId>maven-dependency-tree</artifactId>
-      <version>2.2</version>
     </dependency>
 
     <dependency>

--- a/enforcer-rules/pom.xml
+++ b/enforcer-rules/pom.xml
@@ -27,11 +27,6 @@
   <name>${project.groupId}:${project.artifactId}</name>
   <packaging>jar</packaging>
 
-  <properties>
-    <!-- maven-enforcer-plugin relies on older maven implementations -->
-    <apache-maven.version>3.0</apache-maven.version>
-  </properties>
-
   <dependencies>
     <dependency>
       <groupId>org.sonatype.ossindex.maven</groupId>

--- a/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
+++ b/enforcer-rules/src/main/java/org/sonatype/ossindex/maven/enforcer/BanVulnerableDependencies.java
@@ -20,6 +20,8 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.maven.project.DefaultProjectBuildingRequest;
+import org.apache.maven.project.ProjectBuildingRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportAssistant;
 import org.sonatype.ossindex.maven.common.ComponentReportRequest;
 import org.sonatype.ossindex.maven.common.ComponentReportResult;
@@ -312,7 +314,11 @@ public class BanVulnerableDependencies
         artifactFilter = new CumulativeScopeArtifactFilter(scopes);
       }
 
-      DependencyNode node = graphBuilder.buildDependencyGraph(project, artifactFilter);
+      ProjectBuildingRequest buildingRequest =
+              new DefaultProjectBuildingRequest( session.getProjectBuildingRequest() );
+      buildingRequest.setProject( project );
+
+      DependencyNode node = graphBuilder.buildDependencyGraph(buildingRequest, artifactFilter);
       collectArtifacts(result, node);
 
       return result;

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,8 @@
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
-    <apache-maven.version>3.0</apache-maven.version>
+    <apache-maven.version>3.5.0</apache-maven.version>
+    <maven.plugin-annotations.version>3.6.0</maven.plugin-annotations.version>
     <jackson.version>2.9.10</jackson.version>
     <dionysus.version>1.0.3</dionysus.version>
 
@@ -137,7 +138,7 @@
       <dependency>
         <groupId>org.sonatype.ossindex</groupId>
         <artifactId>ossindex-service-client</artifactId>
-        <version>1.1.1</version>
+        <version>1.8.1</version>
       </dependency>
 
       <dependency>
@@ -149,7 +150,7 @@
       <dependency>
         <groupId>org.apache.maven.plugin-tools</groupId>
         <artifactId>maven-plugin-annotations</artifactId>
-        <version>${apache-maven.version}</version>
+        <version>${maven.plugin-annotations.version}</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -92,8 +92,8 @@
   </distributionManagement>
 
   <properties>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
 
     <apache-maven.version>3.0</apache-maven.version>
     <jackson.version>2.9.10</jackson.version>
@@ -185,7 +185,7 @@
       <dependency>
         <groupId>org.apache.maven.shared</groupId>
         <artifactId>maven-dependency-tree</artifactId>
-        <version>3.0.1</version>
+        <version>3.1.0</version>
       </dependency>
 
       <dependency>
@@ -365,7 +365,7 @@
             <configuration>
               <rules>
                 <byteCodeRule implementation="org.owasp.maven.enforcer.rule.ClassFileFormatRule">
-                  <supportedClassFileFormat>51</supportedClassFileFormat>
+                  <supportedClassFileFormat>52</supportedClassFileFormat>
                 </byteCodeRule>
               </rules>
             </configuration>
@@ -379,7 +379,7 @@
         <configuration>
           <signature>
             <groupId>org.codehaus.mojo.signature</groupId>
-            <artifactId>java17</artifactId>
+            <artifactId>java18</artifactId>
             <version>1.0</version>
           </signature>
         </configuration>


### PR DESCRIPTION
Breaks Java 1.7 compatibility. Is this still a hard requirement?

Closes #56 

Inspired by changes in https://github.com/mojohaus/extra-enforcer-rules/commit/d380fe56a7317a237bbce5b94fbab7f4581d3d1b