### PR TITLE
Fix 'illegal method name' errors in test

### DIFF
--- a/common/src/test/java/org/sonatype/ossindex/maven/common/ComponentReportAssistantTest.groovy
+++ b/common/src/test/java/org/sonatype/ossindex/maven/common/ComponentReportAssistantTest.groovy
@@ -122,7 +122,7 @@ class ComponentReportAssistantTest
   }
 
   @Test
-  void 'inclusion matching; no vulnerabilities'() {
+  void 'inclusion matching, no vulnerabilities'() {
     def request = new ComponentReportRequest()
     def result = new ComponentReportResult()
     def report = new ComponentReport(
@@ -134,7 +134,7 @@ class ComponentReportAssistantTest
   }
 
   @Test
-  void 'inclusion matching; exclude by id'() {
+  void 'inclusion matching, exclude by id'() {
     def request = new ComponentReportRequest()
     def result = new ComponentReportResult()
 
@@ -165,7 +165,7 @@ class ComponentReportAssistantTest
   }
 
   @Test
-  void 'inclusion matching; exclude by cvss score'() {
+  void 'inclusion matching, exclude by cvss score'() {
     def request = new ComponentReportRequest()
     def result = new ComponentReportResult()
 
@@ -193,7 +193,7 @@ class ComponentReportAssistantTest
   }
 
   @Test
-  void 'inclusion matching; exclude by coordinates'() {
+  void 'inclusion matching, exclude by coordinates'() {
     def request = new ComponentReportRequest()
     def result = new ComponentReportResult()
 


### PR DESCRIPTION
When building on Java 8+, an error was thrown. The issue is the semicolon used in the test method names.

Steps to reproduce:
1. Use Java 8 or higher
2. `./build rebuild`
3. Note the following error:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] org.sonatype.ossindex.maven:ossindex-maven 3.1.1-SNAPSHOT SUCCESS [  1.222 s]
[INFO] org.sonatype.ossindex.maven:ossindex-maven-common .. FAILURE [  2.043 s]
[INFO] org.sonatype.ossindex.maven:ossindex-maven-enforcer-rules SKIPPED
[INFO] org.sonatype.ossindex.maven:ossindex-maven-plugin .. SKIPPED
[INFO] org.sonatype.ossindex.maven:ossindex-maven-testsuite 3.1.1-SNAPSHOT SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 3.784 s
[INFO] Finished at: 2022-01-26T15:14:54-05:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test (default-test) on project ossindex-maven-common: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.18.1:test failed: There was an error in the forked process
[ERROR] java.lang.ClassFormatError: Illegal method name "inclusion matching; no vulnerabilities" in class org/sonatype/ossindex/maven/common/ComponentReportAssistantTest

```

After updating the method names to change the semicolon to a comma, the tests pass as expected:
```
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary:
[INFO] 
[INFO] org.sonatype.ossindex.maven:ossindex-maven 3.1.1-SNAPSHOT SUCCESS [  1.601 s]
[INFO] org.sonatype.ossindex.maven:ossindex-maven-common .. SUCCESS [  3.296 s]
[INFO] org.sonatype.ossindex.maven:ossindex-maven-enforcer-rules SUCCESS [  0.826 s]
[INFO] org.sonatype.ossindex.maven:ossindex-maven-plugin .. SUCCESS [  3.545 s]
[INFO] org.sonatype.ossindex.maven:ossindex-maven-testsuite 3.1.1-SNAPSHOT SUCCESS [  1.609 s]
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 11.386 s
[INFO] Finished at: 2022-01-26T15:16:19-05:00
[INFO] ------------------------------------------------------------------------
```